### PR TITLE
Change Enable Workspace Background Default in Style Settings

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -18,7 +18,7 @@ settings:
       title: Enable Workspace Backgound
       description: Enable Custom Wallpaper background
       type: class-toggle
-      default: CG-workspace-background-image-custom
+      default: true
    -
       id: CG-workspace-background-image
       title: Select Background Image


### PR DESCRIPTION
For Style Settings type `class-toggle`, we should expect `true` or `false`. However, it is set to `CG-workspace-background-image-custom`, which is the default value of the Background Image. Updated default value to `true`.

Tested locally. Fixes #86